### PR TITLE
#25 properly turn off the move even handler onRemove

### DIFF
--- a/leaflet_canvas_layer.js
+++ b/leaflet_canvas_layer.js
@@ -145,7 +145,7 @@ initialize: function (options) {
     this._container.parentNode.removeChild(this._container);
     map.off({
       'viewreset': this._reset,
-      'move': this._render,
+      'move': this.redraw,
       'resize': this._reset,
       'zoomanim': this._animateZoom,
       'zoomend': this._endZoomAnim


### PR DESCRIPTION
For for #25

Wrong handler method was being passed into map.off for the move event which meant the redraw function was still being called on map move.